### PR TITLE
change group number

### DIFF
--- a/sites/all/modules/custom/civicrm_org_providers/civicrm_org_providers.module
+++ b/sites/all/modules/custom/civicrm_org_providers/civicrm_org_providers.module
@@ -149,7 +149,7 @@ function civicrm_org_providers_block_view($block_name){
                 );
                 $groups = civicrm_api('GroupContact', 'get', $groupParams);
                 foreach($groups['values'] as $dontCare => $group){
-                    if ($group['group_id'] == '131') {
+                    if ($group['group_id'] == '487') {
                         $showLink = TRUE;
                     }
                 }


### PR DESCRIPTION
According to josh, group #131 is no longer in use for determining if a contact is a contributor or active contributor.  Instead group #487 has been used, which includes 6 child groups.  I'm changing the group id# so the link should appear (hopefully) on contributor pages such as https://civicrm.org/user/####/edit