### PR TITLE
extdir.pages.inc - Allow opting out of the "ready" filter

### DIFF
--- a/sites/all/modules/custom/extdir/extdir.pages.inc
+++ b/sites/all/modules/custom/extdir/extdir.pages.inc
@@ -249,6 +249,7 @@ function _extdir_pages_filters_parse($filterExpr) {
     'field_extension_ready_value' => 'ready',
   );
 
+  // If a "ver" param is provided, override the default filter. The override could be empty (opt-out).
   if (array_key_exists('ver', $args)) {
     $versionParts = explode('.', $args['ver']);
     $termName = sprintf('CiviCRM %d.%d', $versionParts[0], $versionParts[1]);
@@ -262,6 +263,7 @@ function _extdir_pages_filters_parse($filterExpr) {
     }
   }
 
+  // If a "status" param is provided, override the default filter. The override could be empty (opt-out).
   if (array_key_exists('status', $args)) {
     if (empty($args['status'])) {
       unset($filters['field_extension_release_status_value']);
@@ -271,6 +273,7 @@ function _extdir_pages_filters_parse($filterExpr) {
     }
   }
 
+  // If a "ready" param is provided, override the default filter. The override could be empty (opt-out).
   if (array_key_exists('ready', $args)) {
     if (empty($args['ready'])) {
       unset($filters['field_extension_ready_value']);

--- a/sites/all/modules/custom/extdir/extdir.pages.inc
+++ b/sites/all/modules/custom/extdir/extdir.pages.inc
@@ -271,6 +271,14 @@ function _extdir_pages_filters_parse($filterExpr) {
     }
   }
 
+  if (array_key_exists('ready', $args)) {
+    if (empty($args['ready'])) {
+      unset($filters['field_extension_ready_value']);
+    } else {
+      $filters['field_extension_ready_value'] = $args['ready'];
+    }
+  }
+
   return $filters;
 }
 


### PR DESCRIPTION
I temporarily deployed on `test2.www-test.civicrm.org` and compared these URLs:

 * https://test2.www-test.civicrm.org/extdir/ver=4.7.16|cms=Drupal
 * https://test2.www-test.civicrm.org/extdir/ver=4.7.16|cms=Drupal|status=
 * https://test2.www-test.civicrm.org/extdir/ver=4.7.16|cms=Drupal|status=|ready=

As expected, the list grew more permissive as we opted of more criteria.

(Note: I switched `test2` back to `master`, so the links should be showing the old behavior.)